### PR TITLE
Add illustration dimension fields and position of text and logo

### DIFF
--- a/static/js/src/generate-banner-canvas.js
+++ b/static/js/src/generate-banner-canvas.js
@@ -1,4 +1,4 @@
-import { addText } from "./text";
+import { setText } from "./text";
 import { addUbuntuLogo, addIllustration } from "./images";
 import {
   createColorGradient,
@@ -30,37 +30,32 @@ function generateBannerCanvas(options) {
   createMidGreyGradient(ctxfacebook);
 
   addUbuntuLogo(ctxfacebook, {
-    x: 100,
-    y: 219.8,
-    width: 143,
-    height: 32,
+    x: 70,
+    y: 52,
+    width: 241,
+    height: 64,
   });
 
   addIllustration(ctxfacebook, options.illustrationUrl, {
-    x: 720,
-    y: 192,
-    width: 244,
-    height: 250,
+    orientation: "right",
   });
 
-  addText(ctxfacebook, {
-    fontWeight: 100,
-    fontSize: 46,
-    text: options.title,
-    x: 100,
-    y: 314.8,
-    maxWidth: 400,
-    lineHeight: 48,
-  });
-
-  addText(ctxfacebook, {
-    fontWeight: 300,
-    fontSize: 20.8979,
-    text: options.subtitle,
-    x: 100,
-    y: 420.8,
-    maxWidth: 400,
-    lineHeight: 30,
+  setText(ctxfacebook, {
+    width: 560,
+    x: 70,
+    y: 210,
+    title: {
+      text: options.title,
+      fontWeight: 100,
+      fontSize: 64,
+      lineHeight: 74,
+    },
+    subtitle: {
+      text: options.subtitle,
+      fontWeight: 300,
+      fontSize: 20,
+      lineHeight: 32,
+    },
   });
 
   // FACEBOOK MOBILE
@@ -85,37 +80,32 @@ function generateBannerCanvas(options) {
   createMidGreyGradient(ctxfacebookmobile);
 
   addUbuntuLogo(ctxfacebookmobile, {
-    x: 100,
-    y: 378,
-    width: 143,
-    height: 32,
+    x: 70,
+    y: 52,
+    width: 295,
+    height: 79,
   });
 
   addIllustration(ctxfacebookmobile, options.illustrationUrl, {
-    x: 648,
-    y: 418,
-    width: 244,
-    height: 250,
+    orientation: "bottom",
   });
 
-  addText(ctxfacebookmobile, {
-    fontWeight: 100,
-    fontSize: 46,
-    text: options.title,
-    x: 100,
-    y: 473,
-    maxWidth: 400,
-    lineHeight: 48,
-  });
-
-  addText(ctxfacebookmobile, {
-    fontWeight: 300,
-    fontSize: 20.8979,
-    text: options.subtitle,
-    x: 100,
-    y: 579,
-    maxWidth: 400,
-    lineHeight: 30,
+  setText(ctxfacebookmobile, {
+    width: 800,
+    x: 70,
+    y: 230,
+    title: {
+      text: options.title,
+      fontWeight: 100,
+      fontSize: 76,
+      lineHeight: 90,
+    },
+    subtitle: {
+      text: options.subtitle,
+      fontWeight: 300,
+      fontSize: 24,
+      lineHeight: 38,
+    },
   });
 
   // FACEBOOK916
@@ -140,37 +130,32 @@ function generateBannerCanvas(options) {
   createMidGreyGradient(ctxfacebook916);
 
   addUbuntuLogo(ctxfacebook916, {
-    x: 30,
-    y: 175,
-    width: 143,
-    height: 32,
+    x: 43,
+    y: 24,
+    width: 139,
+    height: 37,
   });
 
   addIllustration(ctxfacebook916, options.illustrationUrl, {
-    x: 30,
-    y: 50,
-    width: 102,
-    height: 100,
+    orientation: "bottom",
   });
 
-  addText(ctxfacebook916, {
-    fontWeight: 100,
-    fontSize: 36,
-    text: options.title,
-    x: 30,
-    y: 265,
-    maxWidth: 320,
-    lineHeight: 48,
-  });
-
-  addText(ctxfacebook916, {
-    fontWeight: 300,
-    fontSize: 20.8979,
-    text: options.subtitle,
-    x: 30,
-    y: 366,
-    maxWidth: 320,
-    lineHeight: 30,
+  setText(ctxfacebook916, {
+    width: 330,
+    x: 43,
+    y: 110,
+    title: {
+      text: options.title,
+      fontWeight: 100,
+      fontSize: 36,
+      lineHeight: 42,
+    },
+    subtitle: {
+      text: options.subtitle,
+      fontWeight: 300,
+      fontSize: 16,
+      lineHeight: 24,
+    },
   });
 
   // TWITTER
@@ -195,37 +180,32 @@ function generateBannerCanvas(options) {
   createMidGreyGradient(ctxtwitter);
 
   addUbuntuLogo(ctxtwitter, {
-    x: 30,
-    y: 146.3,
-    width: 143,
-    height: 32,
+    x: 420,
+    y: 40,
+    width: 170,
+    height: 45,
   });
 
   addIllustration(ctxtwitter, options.illustrationUrl, {
-    x: 480,
-    y: 87,
-    width: 244,
-    height: 250,
+    orientation: "left",
   });
 
-  addText(ctxtwitter, {
-    fontWeight: 100,
-    fontSize: 36,
-    text: options.title,
-    x: 30,
-    y: 236.3,
-    maxWidth: 400,
-    lineHeight: 48,
-  });
-
-  addText(ctxtwitter, {
-    fontWeight: 300,
-    fontSize: 20.8979,
-    text: options.subtitle,
-    x: 30,
-    y: 337.3,
-    maxWidth: 400,
-    lineHeight: 30,
+  setText(ctxtwitter, {
+    width: 360,
+    x: 420,
+    y: 165,
+    title: {
+      text: options.title,
+      fontWeight: 100,
+      fontSize: 42,
+      lineHeight: 48,
+    },
+    subtitle: {
+      text: options.subtitle,
+      fontWeight: 300,
+      fontSize: 16,
+      lineHeight: 24,
+    },
   });
 
   // TWITTERSQUARE
@@ -250,37 +230,32 @@ function generateBannerCanvas(options) {
   createMidGreyGradient(ctxtwittersquare);
 
   addUbuntuLogo(ctxtwittersquare, {
-    x: 30,
-    y: 280,
-    width: 143,
-    height: 32,
+    x: 70,
+    y: 50,
+    width: 223,
+    height: 59,
   });
 
   addIllustration(ctxtwittersquare, options.illustrationUrl, {
-    x: 480,
-    y: 278,
-    width: 244,
-    height: 250,
+    orientation: "bottom",
   });
 
-  addText(ctxtwittersquare, {
-    fontWeight: 100,
-    fontSize: 36,
-    text: options.title,
-    x: 30,
-    y: 370,
-    maxWidth: 400,
-    lineHeight: 48,
-  });
-
-  addText(ctxtwittersquare, {
-    fontWeight: 300,
-    fontSize: 20.8979,
-    text: options.subtitle,
-    x: 30,
-    y: 471,
-    maxWidth: 400,
-    lineHeight: 30,
+  setText(ctxtwittersquare, {
+    width: 630,
+    x: 70,
+    y: 190,
+    title: {
+      text: options.title,
+      fontWeight: 100,
+      fontSize: 58,
+      lineHeight: 68,
+    },
+    subtitle: {
+      text: options.subtitle,
+      fontWeight: 300,
+      fontSize: 19,
+      lineHeight: 32,
+    },
   });
 }
 

--- a/static/js/src/generate-banner-canvas.js
+++ b/static/js/src/generate-banner-canvas.js
@@ -22,12 +22,12 @@ function generateBannerCanvas(options) {
     height: 628,
   });
 
-  createLightGreyGradient(ctxfacebook, {
-    width: 1200,
-    height: 628,
-  });
+  // createLightGreyGradient(ctxfacebook, {
+  //   width: 1200,
+  //   height: 628,
+  // });
 
-  createMidGreyGradient(ctxfacebook);
+  // createMidGreyGradient(ctxfacebook);
 
   addUbuntuLogo(ctxfacebook, {
     x: 70,

--- a/static/js/src/generate-banner-canvas.js
+++ b/static/js/src/generate-banner-canvas.js
@@ -22,10 +22,10 @@ function generateBannerCanvas(options) {
     height: 628,
   });
 
-  // createLightGreyGradient(ctxfacebook, {
-  //   width: 1200,
-  //   height: 628,
-  // });
+  createLightGreyGradient(ctxfacebook, {
+    width: 1200,
+    height: 628,
+  });
 
   // createMidGreyGradient(ctxfacebook);
 

--- a/static/js/src/gradients.js
+++ b/static/js/src/gradients.js
@@ -59,21 +59,16 @@ function createWhiteGradient(context, dimensions) {
 }
 
 function createLightGreyGradient(context, dimensions) {
-  const gradient = context.createLinearGradient(
-    0,
-    0,
-    dimensions.width,
+  context.fillStyle = "rgba(0, 0, 0, 0.1)";
+  context.rotate((-10 * Math.PI) / 180);
+  context.fillRect(
+    -dimensions.width,
+    dimensions.height / 1.4,
+    dimensions.width * 2,
     dimensions.height
   );
-
-  gradient.addColorStop(0, "rgba(228, 228, 228, 0.54)");
-  gradient.addColorStop(0.5, "rgba(228, 228, 228, 0.54)");
-
-  context.globalAlpha = 0.05;
-  context.fillStyle = gradient;
-  context.rotate((-12 * Math.PI) / 180);
-  context.fillRect(-250, 400, dimensions.width * 1.25, dimensions.height);
-  context.rotate((12 * Math.PI) / 180);
+  context.rotate((10 * Math.PI) / 180);
+  context.fillRect(0, 0, dimensions.width, dimensions.height);
 }
 
 function createMidGreyGradient(context) {

--- a/static/js/src/gradients.js
+++ b/static/js/src/gradients.js
@@ -46,23 +46,16 @@ function createColorGradient(context, background, dimensions) {
 }
 
 function createWhiteGradient(context, dimensions) {
-  const gradient = context.createLinearGradient(
-    0,
-    0,
-    dimensions.width,
-    dimensions.height + 200
-  );
-
-  gradient.addColorStop(0, "rgba(247, 247, 247, 1)");
-  gradient.addColorStop(0.5, "rgba(247, 247, 247, 1)");
-  gradient.addColorStop(0.5, "rgba(247, 247, 247, 0)");
-  gradient.addColorStop(1, "rgba(247, 247, 247, 0)");
-
-  context.globalAlpha = 0.02;
-  context.fillStyle = gradient;
+  context.fillStyle = "rgba(255, 255, 255, 0.1)";
   context.rotate((10 * Math.PI) / 180);
-  context.fillRect(0, 0, dimensions.width * 1.25, dimensions.height);
+  context.fillRect(
+    0,
+    -dimensions.height,
+    dimensions.width * 2,
+    dimensions.height
+  );
   context.rotate((-10 * Math.PI) / 180);
+  context.fillRect(0, 0, dimensions.width, dimensions.height);
 }
 
 function createLightGreyGradient(context, dimensions) {

--- a/static/js/src/images.js
+++ b/static/js/src/images.js
@@ -1,16 +1,54 @@
 function drawImage(context, image, dimensions) {
+  let imageWidth = image.width;
+  let imageHeight = image.height;
+
+  const canvasWidth = context.canvas.width;
+  const canvasHeight = context.canvas.height;
+  const illustrationAspectRatio = imageHeight / imageWidth;
+
+  let illustrationWrapperWidth = canvasWidth;
+  let illustrationWrapperHeight = canvasHeight;
+  let illustrationOffsetLeft = 0;
+  let illustrationOffsetTop = 0;
+
+  if (dimensions.orientation === "left" || dimensions.orientation === "right") {
+    illustrationWrapperWidth = canvasWidth / 2;
+  }
+
+  if (dimensions.orientation === "right") {
+    illustrationOffsetLeft = illustrationWrapperWidth;
+  }
+
+  if (dimensions.orientation === "bottom") {
+    illustrationWrapperHeight = canvasHeight / 2;
+    imageWidth = illustrationWrapperHeight * 0.9;
+    imageHeight = illustrationAspectRatio * imageWidth;
+    illustrationOffsetTop = illustrationWrapperHeight;
+  }
+
+  if (imageWidth > illustrationWrapperWidth) {
+    imageWidth = illustrationWrapperWidth * 0.8;
+    imageHeight = illustrationAspectRatio * imageWidth;
+  }
+
+  dimensions.x =
+    illustrationOffsetLeft + (illustrationWrapperWidth - imageWidth) / 2;
+
+  dimensions.y =
+    illustrationOffsetTop + (illustrationWrapperHeight - imageHeight) / 2;
+
+  context.drawImage(image, dimensions.x, dimensions.y, imageWidth, imageHeight);
+}
+
+function addUbuntuLogo(context, dimensions) {
+  const ubuntuLogoImage = document.getElementById("ubuntu-logo");
   context.drawImage(
-    image,
+    ubuntuLogoImage,
     dimensions.x,
     dimensions.y,
     dimensions.width,
     dimensions.height
   );
-}
-
-function addUbuntuLogo(context, dimensions) {
-  const ubuntuLogoImage = document.getElementById("ubuntu-logo");
-  drawImage(context, ubuntuLogoImage, dimensions);
 }
 
 function addIllustration(context, illustrationUrl, dimensions) {

--- a/static/js/src/text.js
+++ b/static/js/src/text.js
@@ -1,36 +1,58 @@
-function wrapText(context, text, x, y, maxWidth, lineHeight) {
-  const words = text.split(" ");
+function setText(context, options) {
+  // create title
+  context.font = `normal ${options.title.fontWeight} ${options.title.fontSize}px Ubuntu`;
+  context.fillStyle = "#ffffff";
 
-  let line = "";
+  const title = options.title.text;
+  const titleWords = title.split(" ");
 
-  for (let n = 0; n < words.length; n++) {
-    const testLine = line + words[n] + " ";
-    const metrics = context.measureText(testLine);
-    const testWidth = metrics.width;
+  let titleX = options.x;
+  let titleY = options.y;
+  let titleLine = "";
+  let numberOfTitleLines = 1;
 
-    if (testWidth > maxWidth && n > 0) {
-      context.fillText(line, x, y);
-      line = words[n] + " ";
-      y += lineHeight;
+  for (let n = 0; n < titleWords.length; n++) {
+    const titleTestLine = titleLine + titleWords[n] + " ";
+    const titleMetrics = context.measureText(titleTestLine);
+    const titleTestWidth = titleMetrics.width;
+
+    if (titleTestWidth > options.width && n > 0) {
+      context.fillText(titleLine, titleX, titleY);
+      numberOfTitleLines++;
+      titleLine = titleWords[n] + " ";
+      titleY += options.title.lineHeight;
     } else {
-      line = testLine;
+      titleLine = titleTestLine;
     }
   }
 
-  context.fillText(line, x, y);
-}
+  context.fillText(titleLine, titleX, titleY);
 
-function addText(context, options) {
-  context.font = `normal ${options.fontWeight} ${options.fontSize}px Ubuntu`;
+  // create subtitle
+  context.font = `normal ${options.subtitle.fontWeight} ${options.subtitle.fontSize}px Ubuntu`;
   context.fillStyle = "#ffffff";
-  wrapText(
-    context,
-    options.text,
-    options.x,
-    options.y,
-    options.maxWidth,
-    options.lineHeight
-  );
+
+  const subtitle = options.subtitle.text;
+  const subtitleWords = subtitle.split(" ");
+
+  let subtitleY = numberOfTitleLines * options.title.lineHeight + options.y;
+  let subtitleLine = "";
+
+  for (let n = 0; n < subtitleWords.length; n++) {
+    const subtitleTestLine = subtitleLine + subtitleWords[n] + " ";
+    const subtitleMetrics = context.measureText(subtitleTestLine);
+    const subtitleTestWidth = subtitleMetrics.width;
+
+    if (subtitleTestWidth > options.width && n > 0) {
+      context.fillText(subtitleLine, options.x, subtitleY);
+      subtitleLine = subtitleWords[n] + " ";
+      subtitleY += options.subtitle.lineHeight;
+    } else {
+      subtitleLine = subtitleTestLine;
+    }
+  }
+
+  context.fillText(subtitleLine, titleX, subtitleY);
 }
 
-export { addText };
+export { setText };

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,11 +25,11 @@
         <div class="row">
           <div class="col-8">
             <form>
-              <label for="title">Title</label>
-              <input type="text" name="title" id="title" value="{{ banner_data.title }}" required>
+              <label for="title">Title (max 50 characters)</label>
+              <input type="text" name="title" id="title" value="{{ banner_data.title }}" maxlength="50" required>
 
-              <label for="subtitle">Subtitle</label>
-              <textarea name="subtitle" id="subtitle">{{ banner_data.subtitle }}</textarea>
+              <label for="subtitle">Subtitle (max 120 characters)</label>
+              <textarea name="subtitle" id="subtitle" maxlength="120" rows="4">{{ banner_data.subtitle }}</textarea>
 
               <label for="illustration_url">Illustration URL</label>
               <input type="url" name="illustration_url" id="illustration_url" value="{{ banner_data.illustration_url }}" required>
@@ -53,7 +53,7 @@
         <div class="u-fixed-width">
           <h2>Preview</h2>
 
-          <img class="u-hide" id="ubuntu-logo" src="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg" alt="Ubuntu" width="143" height="32">
+          <img class="u-hide" id="ubuntu-logo" src="https://assets.ubuntu.com/v1/e6a014ae-ubuntu_logo_white_orange.svg" alt="Ubuntu" width="293" height="78">
 
           <h4>Facebook &amp; LinkedIn - 1200 x 628</h4>
           <canvas id="facebook" width="1200" height="628">


### PR DESCRIPTION
## Done
- Add fields to specify illustration dimensions (used for aspect ratio purposes)
- Position and sized logo as specified in [these designs](https://app.zeplin.io/project/5efb66d1ae9030a1cd756466/dashboard?sid=5efb6708c2477e961a15ca28)
- Positioned and sized text as specified in [these designs](https://app.zeplin.io/project/5efb66d1ae9030a1cd756466/dashboard?sid=5efb6708c2477e961a15ca28)

## QA
- Checkout this feature branch
- Run the site using `dotrun`
- View the site locally in your browser at: [http://0.0.0.0:8057](http://0.0.0.0:8057)
- Check that this URL renders images that are close to [the designs](https://app.zeplin.io/project/5efb66d1ae9030a1cd756466/dashboard?sid=5efb6708c2477e961a15ca28): http://localhost:8057/?title=Ubuntu+for+the+Internet+of+Things+in+the+future&subtitle=From+smart+homes+to+smart+drones%2C+robots%2C+and+industrial+systems%2C+Ubuntu+is+the+new+standard+for+embedded+Linux.&illustration_url=https%3A%2F%2Fassets.ubuntu.com%2Fv1%2F9c1315fb-IOT_Ubuntu_devices_inforgrapic%2Bv3.svg&illustration_width=470&illustration_height=320&background=grad
- Try changing the text and check that the position of the subtitle reacts to the length of the title

**Note**: The text will overflow the illustration or the container if there is too much - we can perhaps prevent this with character count limits?

## Issue / Card
Fixes #3, #7