### PR TITLE
Fix so png images show in Firefox

### DIFF
--- a/static/js/src/images.js
+++ b/static/js/src/images.js
@@ -35,13 +35,19 @@ function drawImage(context, image, options) {
       imageHeight / 2;
   }
 
-  context.drawImage(
-    image,
-    imageXPosition,
-    imageYPosition,
-    imageWidth,
-    imageHeight
-  );
+  const newImage = new Image();
+
+  newImage.addEventListener("load", () => {
+    context.drawImage(
+      newImage,
+      imageXPosition,
+      imageYPosition,
+      imageWidth,
+      imageHeight
+    );
+  });
+
+  newImage.src = image.src;
 }
 
 function addUbuntuLogo(context, dimensions) {


### PR DESCRIPTION
## Done

Changed how images are created so that PNG images are rendered to the canvas in Firefox

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8057/?title=Ubuntu+for+the+internet+of+things&subtitle=From+smart+homes+to+smart+drones%2C+robots%2C+and+industrial+systems%2C+Ubuntu+is+the+new+standard+for+embedded+Linux.&illustration_url=https%3A%2F%2Fassets.ubuntu.com%2Fv1%2Fc45d516d-plum-grid.png&background=dark#banner-form-modal
- Check that the illustration is rendered on the canvas