### PR TITLE
Only show Firefox bug message in Firefox

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,11 +28,17 @@
 
   <section class="p-strip--light is-bordered">
     <div class="u-fixed-width">
-      <div class="p-notification--caution">
+      <div class="p-notification--caution u-hide" id="firefox-bug-banner">
         <p class="p-notification__response">
           <span class="p-notification__status">Note:</span> Due to a bug in Firefox, illustrations will not be rendered to the canvas. Please use <a class="p-link--external" href="https://www.google.com/intl/en_uk/chrome/">Google Chrome</a>.
         </p>
       </div>
+
+      <script>
+        if (navigator.userAgent.toLowerCase().indexOf("firefox") > -1) {
+          document.getElementById("firefox-bug-banner").classList.remove("u-hide")
+        }
+      </script>
     </div>
     <div class="row">
       <div class="col-6">


### PR DESCRIPTION
## Done

Check user agent to see if the browser is Firefox, if so then show the Firefox bug notification

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8057 in Firefox
- Check that there is a notification matching the one in the screenshot below
- View the site in Chrome and check that there is no notification

## Screenshots
![Screenshot from 2020-07-10 15-05-06](https://user-images.githubusercontent.com/501889/87163627-8c809300-c2bf-11ea-95d4-6492d8268bc9.png)
