### PR TITLE
Add link to Firefox bug issue

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
     <div class="u-fixed-width">
       <div class="p-notification--caution u-hide" id="firefox-bug-banner">
         <p class="p-notification__response">
-          <span class="p-notification__status">Note:</span> Due to a bug in Firefox, illustrations will not be rendered to the canvas. Please use <a class="p-link--external" href="https://www.google.com/intl/en_uk/chrome/">Google Chrome</a>.
+          <span class="p-notification__status">Note:</span> Due to a <a class="p-link--external" href="https://github.com/canonical-web-and-design/tools.demos.haus/issues/22">bug in Firefox</a>, illustrations will not be rendered to the canvas. Please use <a class="p-link--external" href="https://www.google.com/intl/en_uk/chrome/">Google Chrome</a>.
         </p>
       </div>
 


### PR DESCRIPTION
## Done

Added link to GitHub issue regarding Firefox SVG display bug

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8057 in Firefox
- Check that the notification at the top of the page links to the GitHub issue for the Firefox SVG bug on this repo
