### PR TITLE
Fix entity decoding issues in text

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,19 @@ jobs:
           command: |
             coverage run  --source=. -m unittest discover tests
             bash <(curl -s https://codecov.io/bash) -cF python
+  test-js:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Test JS
+        run: |
+          yarn test-js
+          bash <(curl -s https://codecov.io/bash) -cF javascript
 workflows:
   version: 2
   build:
@@ -84,3 +97,4 @@ workflows:
       - lint-scss
       - lint-python
       - test-python
+      - test-js

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint-scss": "stylelint 'static/**/*.scss'",
     "serve": "./entrypoint 0.0.0.0:${PORT}",
     "test": "yarn run lint-scss && yarn run lint-python && yarn run test-python",
+    "test-js": "jest",
     "test-python": "python3 -m unittest discover tests",
     "start": "yarn run build && concurrently --kill-others --raw 'yarn run watch-js' 'yarn run serve'",
     "lint-js": "eslint static/js/src/**/*.js",

--- a/static/js/src/content.js
+++ b/static/js/src/content.js
@@ -1,4 +1,5 @@
 import { addIllustration } from "./images";
+import decodeHtmlEntities from "./utils/decodeHtmlEntities";
 
 function setFont(context, fontStyle) {
   context.font = fontStyle;
@@ -35,13 +36,21 @@ function setContent(context, options) {
 
   setFont(context, titleFontStyle);
 
-  const titleLines = getTextLines(context, options.title.text, options.width);
+  const titleText = options.title.text.replace("&amp;", "&");
+
+  const titleLines = getTextLines(
+    context,
+    decodeHtmlEntities(titleText),
+    options.width
+  );
 
   setFont(context, subtitleFontStyle);
 
+  const subtitleText = options.subtitle.text.replace("&amp;", "&");
+
   const subtitleLines = getTextLines(
     context,
-    options.subtitle.text,
+    decodeHtmlEntities(subtitleText),
     options.width
   );
 

--- a/static/js/src/utils/decodeHtmlEntities.js
+++ b/static/js/src/utils/decodeHtmlEntities.js
@@ -1,0 +1,7 @@
+function decodeHtmlEntities(str) {
+  return str.replace(/&#(\d+);/g, (match, dec) => {
+    return String.fromCharCode(dec);
+  });
+}
+
+export default decodeHtmlEntities;

--- a/static/js/src/utils/decodeHtmlEntities.test.js
+++ b/static/js/src/utils/decodeHtmlEntities.test.js
@@ -1,0 +1,12 @@
+import decodeHtmlEntities from "./decodeHtmlEntities";
+
+describe("decodeHtmlEntities", () => {
+  it("decodes HTML entites into unicode characters", () => {
+    expect(decodeHtmlEntities("&#33;")).toEqual("!");
+    expect(decodeHtmlEntities("&#37;")).toEqual("%");
+    expect(decodeHtmlEntities("&#40;")).toEqual("(");
+    expect(decodeHtmlEntities("&#60;")).toEqual("<");
+    expect(decodeHtmlEntities("&#64;")).toEqual("@");
+    expect(decodeHtmlEntities("&#125;")).toEqual("}");
+  });
+});

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,6 +1,7 @@
 from canonicalwebteam.flask_base.app import FlaskBase
 from flask import render_template, request, Response
 from requests import get
+from html import unescape
 
 import os
 
@@ -16,7 +17,21 @@ app = FlaskBase(
 
 @app.route("/")
 def index():
-    return render_template("index.html", banner_data=request.args)
+    banner_data = {}
+
+    if "title" in request.args:
+        banner_data["title"] = unescape(request.args["title"])
+
+    if "subtitle" in request.args:
+        banner_data["subtitle"] = unescape(request.args["subtitle"])
+
+    if "illustration_url" in request.args:
+        banner_data["illustration_url"] = request.args["illustration_url"]
+
+    if "background" in request.args:
+        banner_data["background"] = request.args["background"]
+
+    return render_template("index.html", banner_data=banner_data)
 
 
 @app.route("/fetch/<path:path>")


### PR DESCRIPTION
## Done

Fix issues with decoding HTML entities

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8057
- Enter text to create banners using HTML entities e.g. `&amp;`, `&mdash;` and characters such as quotes
- Check that they render in the text as expected

## Issue / Card

Fixes #24 