### PR TITLE
Fix broken jpg downloads

### DIFF
--- a/static/js/src/handle-downloads.js
+++ b/static/js/src/handle-downloads.js
@@ -14,9 +14,11 @@ function handleDownloads() {
 handleDownloads();
 
 function setupDownloadLinks(canvas, linkId) {
-  const downloadUrl = canvas.toDataURL("image/jpeg");
-  const downloadLink = document.getElementById(linkId);
-  downloadLink.href = downloadUrl;
+  setTimeout(() => {
+    const downloadUrl = canvas.toDataURL("image/jpeg");
+    const downloadLink = document.getElementById(linkId);
+    downloadLink.href = downloadUrl;
+  }, 0);
 }
 
 export { setupDownloadLinks };

--- a/templates/index.html
+++ b/templates/index.html
@@ -66,7 +66,7 @@
   </section>
 
   <img class="u-hide" id="ubuntu-logo" src="/static/img/ubuntu_logo.svg" alt="">
-  <img class="u-hide" id="illustration" src="/fetch/{{ banner_data.illustration_url }}" alt="">
+  <img class="u-hide" id="illustration" src="/?image={{ banner_data.illustration_url }}" alt="">
 
   <section class="p-strip u-no-padding--bottom" id="facebook-and-linkedin-banner">
     <div class="u-fixed-width">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -31,16 +31,15 @@ def index():
     if "background" in request.args:
         banner_data["background"] = request.args["background"]
 
-    return render_template("index.html", banner_data=banner_data)
+    if request.args.get("image"):
+        image_url = request.args["image"]
+        image = get(f"{image_url}").content
+        filename, file_extension = os.path.splitext(image_url)
+        mimetype = "image/svg+xml"
 
+        if file_extension == ".png":
+            mimetype = "image/png"
 
-@app.route("/fetch/<path:path>")
-def proxy(path):
-    image = get(f"{path}").content
-    filename, file_extension = os.path.splitext(path)
-    mimetype = "image/svg+xml"
-
-    if file_extension == ".png":
-        mimetype = "image/png"
-
-    return Response(image, mimetype=mimetype)
+        return Response(image, mimetype=mimetype)
+    else:
+        return render_template("index.html", banner_data=banner_data)


### PR DESCRIPTION
## Done

- Changed image proxy to query string rather than a path

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8057/?title=Do+VMware+ao+Charmed+OpenStack&subtitle=Reduza+os+custos+e+aumente+a+efici%C3%AAncia+da+sua+infraestrutura+com+ado%C3%A7%C3%A3o+de+c%C3%B3digo+aberto&illustration_url=https%3A%2F%2Fassets.ubuntu.com%2Fv1%2F2d935f28-openstack-cloud.svg%3Fw%3D367&background=dark#banner-form-modal
- Try downloading the banners and make sure that they all have illustrations

## Issue / Card

Fixes #29 
