### PR TITLE
Update download filename to new naming convention

### DIFF
--- a/static/js/src/content.js
+++ b/static/js/src/content.js
@@ -89,6 +89,7 @@ function setContent(context, options) {
       orientation: options.imageOrientation,
       textHeight: totalTextHeight + options.y - options.subtitle.lineHeight,
       textWidth: options.width,
+      logo: options.logo,
     });
   }
 }

--- a/static/js/src/generate-banner-canvas.js
+++ b/static/js/src/generate-banner-canvas.js
@@ -44,6 +44,7 @@ function generateBannerCanvas(options) {
       lineHeight: 32,
     },
     imageOrientation: "right",
+    logo: options.logo,
   });
 
   setupDownloadLinks(options, canvasfacebook, "facebook-download-button");
@@ -342,10 +343,14 @@ function generateBannerCanvas(options) {
     });
   }
 
+  let yContent160x600 = 120;
+  if (options.logo === "ubuntu+microsoft") {
+    yContent160x600 = 150;
+  }
   setContent(ctxdisplay160x600, {
     width: 130,
     x: 8,
-    y: 150,
+    y: yContent160x600,
     title: {
       text: options.title,
       fontWeight: 100,
@@ -358,7 +363,7 @@ function generateBannerCanvas(options) {
       fontSize: 16,
       lineHeight: 24,
     },
-    imageOrientation: "bottom",
+    imageOrientation: "skyscraper",
   });
 
   setupDownloadLinks(

--- a/static/js/src/generate-banner-canvas.js
+++ b/static/js/src/generate-banner-canvas.js
@@ -285,12 +285,12 @@ function generateBannerCanvas(options) {
   setContent(ctxdisplay728x90, {
     width: 400,
     x: 30,
-    y: 38,
+    y: 34,
     title: {
       text: options.title,
       fontWeight: 100,
       fontSize: 28,
-      lineHeight: 26,
+      lineHeight: 24,
     },
     subtitle: {
       text: options.subtitle,
@@ -349,8 +349,8 @@ function generateBannerCanvas(options) {
     title: {
       text: options.title,
       fontWeight: 100,
-      fontSize: 42,
-      lineHeight: 48,
+      fontSize: 28,
+      lineHeight: 28,
     },
     subtitle: {
       text: options.subtitle,
@@ -526,7 +526,7 @@ function generateBannerCanvas(options) {
   setContent(ctxdisplay600x100, {
     width: 320,
     x: 30,
-    y: 35,
+    y: 30,
     title: {
       text: options.title,
       fontWeight: 100,

--- a/static/js/src/generate-banner-canvas.js
+++ b/static/js/src/generate-banner-canvas.js
@@ -46,7 +46,7 @@ function generateBannerCanvas(options) {
     imageOrientation: "right",
   });
 
-  setupDownloadLinks(canvasfacebook, "facebook-download-button");
+  setupDownloadLinks(options, canvasfacebook, "facebook-download-button");
 
   // FACEBOOK MOBILE
   const canvasfacebookmobile = document.getElementById("facebookmobile");
@@ -93,7 +93,11 @@ function generateBannerCanvas(options) {
     imageOrientation: "bottom",
   });
 
-  setupDownloadLinks(canvasfacebookmobile, "facebook-mobile-download-button");
+  setupDownloadLinks(
+    options,
+    canvasfacebookmobile,
+    "facebook-mobile-download-button"
+  );
 
   // FACEBOOK916
   const canvasfacebook916 = document.getElementById("facebook916");
@@ -140,7 +144,11 @@ function generateBannerCanvas(options) {
     imageOrientation: "bottom",
   });
 
-  setupDownloadLinks(canvasfacebook916, "facebook-9-16-download-button");
+  setupDownloadLinks(
+    options,
+    canvasfacebook916,
+    "facebook-9-16-download-button"
+  );
 
   // TWITTER
   const canvastwitter = document.getElementById("twitter");
@@ -187,7 +195,7 @@ function generateBannerCanvas(options) {
     imageOrientation: "left",
   });
 
-  setupDownloadLinks(canvastwitter, "twitter-wide-download-button");
+  setupDownloadLinks(options, canvastwitter, "twitter-wide-download-button");
 
   // TWITTERSQUARE
   const canvastwittersquare = document.getElementById("twittersquare");
@@ -234,7 +242,11 @@ function generateBannerCanvas(options) {
     imageOrientation: "bottom",
   });
 
-  setupDownloadLinks(canvastwittersquare, "twitter-square-download-button");
+  setupDownloadLinks(
+    options,
+    canvastwittersquare,
+    "twitter-square-download-button"
+  );
 
   // display-728-90
   const canvasdisplay728x90 = document.getElementById("display-728-90-canvas");
@@ -288,7 +300,11 @@ function generateBannerCanvas(options) {
     },
   });
 
-  setupDownloadLinks(canvasdisplay728x90, "display-728-90-download-button");
+  setupDownloadLinks(
+    options,
+    canvasdisplay728x90,
+    "display-728-90-download-button"
+  );
 
   // display-160-600
   const canvasdisplay160x600 = document.getElementById(
@@ -345,7 +361,11 @@ function generateBannerCanvas(options) {
     imageOrientation: "bottom",
   });
 
-  setupDownloadLinks(canvasdisplay160x600, "display-160-600-download-button");
+  setupDownloadLinks(
+    options,
+    canvasdisplay160x600,
+    "display-160-600-download-button"
+  );
 
   // display-300-600
   const canvasdisplay300x600 = document.getElementById(
@@ -401,7 +421,11 @@ function generateBannerCanvas(options) {
     imageOrientation: "bottom",
   });
 
-  setupDownloadLinks(canvasdisplay300x600, "display-300-600-download-button");
+  setupDownloadLinks(
+    options,
+    canvasdisplay300x600,
+    "display-300-600-download-button"
+  );
 
   // display-300-250
   const canvasdisplay300x250 = document.getElementById(
@@ -457,7 +481,11 @@ function generateBannerCanvas(options) {
     },
   });
 
-  setupDownloadLinks(canvasdisplay300x250, "display-300-250-download-button");
+  setupDownloadLinks(
+    options,
+    canvasdisplay300x250,
+    "display-300-250-download-button"
+  );
 
   // display-600-100
   const canvasdisplay600x100 = document.getElementById(
@@ -513,7 +541,11 @@ function generateBannerCanvas(options) {
     },
   });
 
-  setupDownloadLinks(canvasdisplay600x100, "display-600-100-download-button");
+  setupDownloadLinks(
+    options,
+    canvasdisplay600x100,
+    "display-600-100-download-button"
+  );
 }
 
 export { generateBannerCanvas };

--- a/static/js/src/generate-banner-canvas.js
+++ b/static/js/src/generate-banner-canvas.js
@@ -289,7 +289,7 @@ function generateBannerCanvas(options) {
     title: {
       text: options.title,
       fontWeight: 100,
-      fontSize: 28,
+      fontSize: 24,
       lineHeight: 24,
     },
     subtitle: {
@@ -530,7 +530,7 @@ function generateBannerCanvas(options) {
     title: {
       text: options.title,
       fontWeight: 100,
-      fontSize: 28,
+      fontSize: 24,
       lineHeight: 24,
     },
     subtitle: {

--- a/static/js/src/handle-downloads.js
+++ b/static/js/src/handle-downloads.js
@@ -13,11 +13,12 @@ function handleDownloads() {
 
 handleDownloads();
 
-function setupDownloadLinks(canvas, linkId) {
+function setupDownloadLinks(options, canvas, linkId) {
   setTimeout(() => {
     const downloadUrl = canvas.toDataURL("image/jpeg");
     const downloadLink = document.getElementById(linkId);
     downloadLink.href = downloadUrl;
+    downloadLink.download = `${options.product} | ${options.partner} | ${options.messaging} | ${options.background} | ${options.language} | ${canvas.width}x${canvas.height}`;
   }, 0);
 }
 

--- a/static/js/src/images.js
+++ b/static/js/src/images.js
@@ -18,15 +18,29 @@ function drawImage(context, image, options) {
   }
 
   if (options.orientation === "right") {
+    let yPosition = canvasHeight / 2 - imageHeight / 2;
+    if (options.logo === "ubuntu+microsoft") {
+      yPosition = yPosition + 10;
+    }
     imageXPosition =
       options.textWidth +
       (canvasWidth - options.textWidth) / 2 -
       imageWidth / 2;
-    imageYPosition = canvasHeight / 2 - imageHeight / 2;
+    imageYPosition = yPosition;
   }
 
   if (options.orientation === "bottom") {
     imageWidth = (canvasHeight - options.textHeight) * 0.7;
+    imageHeight = imageAspectRatio * imageWidth;
+    imageXPosition = canvasWidth / 2 - imageWidth / 2;
+    imageYPosition =
+      options.textHeight +
+      (canvasHeight - options.textHeight) / 2 -
+      imageHeight / 2;
+  }
+
+  if (options.orientation === "skyscraper") {
+    imageWidth = 100;
     imageHeight = imageAspectRatio * imageWidth;
     imageXPosition = canvasWidth / 2 - imageWidth / 2;
     imageYPosition =

--- a/templates/index.html
+++ b/templates/index.html
@@ -213,6 +213,22 @@
           <option value="ubuntu+microsoft" {% if banner_data.logo == 'ubuntu+microsoft' %}selected{% endif %}>Ubuntu + Microsoft</option>
           <option value="none" {% if banner_data.logo == 'none' %}selected{% endif %}>None</option>
         </select>
+        <label for="product">Product</label>
+        <input type="text" name="product" id="product" value="{{ banner_data.product }}" required>
+        <label for="partner">Partner</label>
+        <input type="text" name="partner" id="partner" value="{{ banner_data.partner }}" required>
+        <label for="messaging">Messaging Pillar</label>
+        <input type="text" name="messaging" id="messaging" value="{{ banner_data.messaging }}" required>
+        <label for="language">Language</label>
+        <select name="language" id="language" value="{{ banner_data.language }}" required>
+          <option value="en" {% if banner_data.language == 'en' %}selected{% endif %}>EN</option>
+          <option value="fr" {% if banner_data.language == 'fr' %}selected{% endif %}>FR</option>
+          <option value="es" {% if banner_data.language == 'es' %}selected{% endif %}>ES</option>
+          <option value="de" {% if banner_data.language == 'de' %}selected{% endif %}>DE</option>
+          <option value="it" {% if banner_data.language == 'it' %}selected{% endif %}>IT</option>
+          <option value="jp" {% if banner_data.language == 'jp' %}selected{% endif %}>JP</option>
+          <option value="cn" {% if banner_data.language == 'cn' %}selected{% endif %}>CN</option>
+        </select>
         <button type="submit" class="p-button--positive">Build banners</button>
       </form>
     </div>
@@ -226,7 +242,11 @@
         subtitle: "{{ banner_data.subtitle }}",
         illustrationUrl: "{{ banner_data.illustration_url }}",
         background: "{{ banner_data.background }}",
-        logo: "{{ banner_data.logo }}"
+        logo: "{{ banner_data.logo }}",
+        product: "{{ banner_data.product }}",
+        partner: "{{ banner_data.partner }}",
+        messaging: "{{ banner_data.messaging }}",
+        language: "{{ banner_data.language }}"
       });
     }
   </script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -213,12 +213,17 @@
           <option value="ubuntu+microsoft" {% if banner_data.logo == 'ubuntu+microsoft' %}selected{% endif %}>Ubuntu + Microsoft</option>
           <option value="none" {% if banner_data.logo == 'none' %}selected{% endif %}>None</option>
         </select>
+        <p class="p-heading--4">File naming helpers</p>
+        <p>The file will be optionally named based on these fields in the format:</p>
+        <div class="p-code-snippet">
+          <pre class="p-code-snippet__block">{product}{partner}{messaging pillar}{background}{language}_{banner type}.jpeg</pre>
+        </div>
         <label for="product">Product</label>
-        <input type="text" name="product" id="product" value="{{ banner_data.product }}" required>
+        <input type="text" name="product" id="product" value="{{ banner_data.product }}">
         <label for="partner">Partner</label>
-        <input type="text" name="partner" id="partner" value="{{ banner_data.partner }}" required>
+        <input type="text" name="partner" id="partner" value="{{ banner_data.partner }}">
         <label for="messaging">Messaging Pillar</label>
-        <input type="text" name="messaging" id="messaging" value="{{ banner_data.messaging }}" required>
+        <input type="text" name="messaging" id="messaging" value="{{ banner_data.messaging }}">
         <label for="language">Language</label>
         <select name="language" id="language" value="{{ banner_data.language }}" required>
           <option value="en" {% if banner_data.language == 'en' %}selected{% endif %}>EN</option>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -34,6 +34,18 @@ def index():
     if "logo" in request.args:
         banner_data["logo"] = request.args["logo"]
 
+    if "product" in request.args:
+        banner_data["product"] = unescape(request.args["product"])
+
+    if "partner" in request.args:
+        banner_data["partner"] = unescape(request.args["partner"])
+
+    if "messaging" in request.args:
+        banner_data["messaging"] = unescape(request.args["messaging"])
+
+    if "language" in request.args:
+        banner_data["language"] = request.args["language"]
+
     if request.args.get("image"):
         image_url = request.args["image"]
         image = get(f"{image_url}").content


### PR DESCRIPTION
## Done

- Add new fields to modal - Product, Partner, Message and Language
- Include these along with Style and Size to the download filename
- Make small adjustments to alignment of content and text size to account for longer words and titles 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8057
- Fill out all fields in modal to build banners
- Download each size of banner
- Check the filename follows the naming convention mentioned [here](https://github.com/canonical-web-and-design/web-squad/issues/3829#issue-809170576)

## Issue / Card

Fixes [#3829](https://github.com/canonical-web-and-design/web-squad/issues/3829)
