### PR TITLE
Allow line breaks in banner copy

### DIFF
--- a/static/js/src/content.js
+++ b/static/js/src/content.js
@@ -7,25 +7,34 @@ function setFont(context, fontStyle) {
 }
 
 function getTextLines(context, text, textWidth) {
-  const words = text.split(" ");
+  // To preserve line breaks in the URL, the strings are URI
+  // encoded in the template and need to be decoded,
+  // then we build an array of deliberately placed line breaks.
+  const newLines = decodeURIComponent(text).split(/\r\n|<br>|<br\/>|<br \/>/);
   const lines = [];
 
-  let line = "";
+  // Iterate over the array of line breaks and check that each
+  // line isn't wider than the given banner. If it is, break
+  // the line into multiple lines as necessary.
+  newLines.forEach((newLine) => {
+    const words = newLine.split(" ");
+    let line = "";
 
-  for (let i = 0, ii = words.length; i < ii; i++) {
-    const testLine = line + words[i] + " ";
-    const metrics = context.measureText(testLine);
-    const testWidth = metrics.width;
+    for (let i = 0, ii = words.length; i < ii; i++) {
+      const testLine = line + words[i] + " ";
+      const metrics = context.measureText(testLine);
+      const testWidth = metrics.width;
 
-    if (testWidth > textWidth && i > 0) {
-      lines.push(line);
-      line = words[i] + " ";
-    } else {
-      line = testLine;
+      if (testWidth > textWidth && i > 0) {
+        lines.push(line);
+        line = words[i] + " ";
+      } else {
+        line = testLine;
+      }
     }
-  }
 
-  lines.push(line);
+    lines.push(line);
+  });
 
   return lines;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -243,8 +243,8 @@
   <script>
     if (window.generateBannerCanvas) {
       window.generateBannerCanvas.generateBannerCanvas({
-        title: "{{ banner_data.title }}",
-        subtitle: "{{ banner_data.subtitle }}",
+        title: "{{ banner_data.title|urlencode }}",
+        subtitle: "{{ banner_data.subtitle|urlencode }}",
         illustrationUrl: "{{ banner_data.illustration_url }}",
         background: "{{ banner_data.background }}",
         logo: "{{ banner_data.logo }}",


### PR DESCRIPTION
## Done

- Fixed line breaks and `<br>` preventing banners from being displayed

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8057
- Build a banner, add line breaks or `<br>` tags in the title and/or subtitle fields
  - Try also to break things
- See that the banners render and the line breaks are preserved

## Issue / Card

Fixes #26 

## Screenshots

![Peek 2021-12-09 10-38](https://user-images.githubusercontent.com/2376968/145381353-b3981999-7e9e-4d46-8b70-7e381b1d1f1b.gif)

